### PR TITLE
Spannbale: Create core classes and ColorSpan

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.BaseSpan.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.BaseSpan.cs
@@ -1,0 +1,32 @@
+﻿/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class BaseSpan
+        {
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseSpan_GetMarkupTagName")]
+            public static extern string GetMarkupTagName(global::System.Runtime.InteropServices.HandleRef refSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_BaseSpan")]
+            public static extern void DeleteBaseSpan(global::System.Runtime.InteropServices.HandleRef refSpan);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ForegroundColorBuilder.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ForegroundColorBuilder.cs
@@ -1,0 +1,37 @@
+﻿/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class ForegroundColorSpanBuilder
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ForegroundColorSpanBuilder_Initialize")]
+            public static extern global::System.IntPtr Initialize();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ForegroundColorSpanBuilder_Build")]
+            public static extern global::System.IntPtr Build(global::System.Runtime.InteropServices.HandleRef refBuilder);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ForegroundColorSpanBuilder_WithForegroundColor")]
+            public static extern global::System.IntPtr WithForegroundColor(global::System.Runtime.InteropServices.HandleRef refBuilder, global::System.Runtime.InteropServices.HandleRef argColor);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ForegroundColorSpanBuilder")]
+            public static extern void DeleteForegroundColorSpanBuilder(global::System.Runtime.InteropServices.HandleRef jarg1);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ForegroundColorSpan.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ForegroundColorSpan.cs
@@ -1,0 +1,35 @@
+﻿/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class ForegroundColorSpan
+        {
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ForegroundColorSpan_foregroundcolor_get")]
+            public static extern global::System.IntPtr ForegroundColorGet(global::System.Runtime.InteropServices.HandleRef refForegroundColorSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ForegroundColorSpan_foregroundcolor_defined_get")]
+            public static extern bool ForegroundColorDefinedGet(global::System.Runtime.InteropServices.HandleRef refForegroundColorSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ForegroundColorSpan")]
+            public static extern void DeleteForegroundColorSpan(global::System.Runtime.InteropServices.HandleRef refForegroundColorSpan);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Spannable.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Spannable.cs
@@ -1,0 +1,61 @@
+﻿/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class Spannable
+        {
+            internal static partial class TextLabel
+            {
+                [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Spannable_TextLabel_AttachSpan")]
+                public static extern global::System.IntPtr AttachSpan(global::System.Runtime.InteropServices.HandleRef textLabelRef, global::System.Runtime.InteropServices.HandleRef spanRef, uint start, uint end);
+
+                [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Spannable_TextLabel_DetachSpan")]
+                public static extern global::System.IntPtr DetachSpan(global::System.Runtime.InteropServices.HandleRef textLabelRef, global::System.Runtime.InteropServices.HandleRef spanRef);
+
+                [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Spannable_TextLabel_BuildSpannedText")]
+                public static extern global::System.IntPtr BuildSpannedText(global::System.Runtime.InteropServices.HandleRef textLabelRef);
+            }
+
+            internal static partial class TextField
+            {
+                [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Spannable_TextField_AttachSpan")]
+                public static extern global::System.IntPtr AttachSpan(global::System.Runtime.InteropServices.HandleRef textFieldRef, global::System.Runtime.InteropServices.HandleRef spanRef, uint start, uint end);
+
+                [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Spannable_TextField_DetachSpan")]
+                public static extern global::System.IntPtr DetachSpan(global::System.Runtime.InteropServices.HandleRef textFieldRef, global::System.Runtime.InteropServices.HandleRef spanRef);
+
+                [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Spannable_TextField_BuildSpannedText")]
+                public static extern global::System.IntPtr BuildSpannedText(global::System.Runtime.InteropServices.HandleRef textFieldRef);
+            }
+
+            internal static partial class TextEditor
+            {
+                [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Spannable_TextEditor_AttachSpan")]
+                public static extern global::System.IntPtr AttachSpan(global::System.Runtime.InteropServices.HandleRef textEditorRef, global::System.Runtime.InteropServices.HandleRef spanRef, uint start, uint end);
+
+                [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Spannable_TextEditor_DetachSpan")]
+                public static extern global::System.IntPtr DetachSpan(global::System.Runtime.InteropServices.HandleRef textEditorRef, global::System.Runtime.InteropServices.HandleRef spanRef);
+
+                [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Spannable_TextEditor_BuildSpannedText")]
+                public static extern global::System.IntPtr BuildSpannedText(global::System.Runtime.InteropServices.HandleRef textEditorRef);
+            }
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/Text/Spannable.cs
+++ b/src/Tizen.NUI/src/public/Text/Spannable.cs
@@ -1,0 +1,255 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.ComponentModel;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Text.Spans;
+
+namespace Tizen.NUI.Text
+{
+    /// <summary>
+    /// Spans are markup objects that can be attached to and detached from text.
+    /// They can be applied to whole paragraphs or to parts of the text.
+    /// The style is changed dynamically on parts of the text.
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class Spannable
+    {
+
+
+        private static void ValidateRange(int start, int end)
+        {
+            if (start < 0)
+                throw new global::System.ArgumentOutOfRangeException(nameof(start), "Value is less than zero");
+            if (end < 0)
+                throw new global::System.ArgumentOutOfRangeException(nameof(end), "Value is less than zero");
+        }
+
+        private static void CheckSWIGPendingException()
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Apply the given span on the given range of text.<br />
+        /// </summary>
+        /// <param name="textLabel">The TextLabel control containing the text.</param>
+        /// <param name="span">TThe span of style to apply it on text from startIndex to endIndex</param>
+        /// <param name="startIndex">The start index of the text to apply span (included)</param>
+        /// <param name="endIndex">The end index of the text  The end index to apply span (included)</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void AttachSpan(TextLabel textLabel, BaseSpan span, int startIndex, int endIndex)
+        {
+            if (textLabel == null)
+            {
+                throw new ArgumentNullException(null, "textLabel object is null");
+            }
+
+            if (span == null)
+            {
+                throw new ArgumentNullException(null, "span object is null");
+            }
+
+            ValidateRange(startIndex, endIndex);
+
+            Interop.Spannable.TextLabel.AttachSpan(textLabel.SwigCPtr,span.SwigCPtr, (uint)startIndex, (uint)endIndex);
+            CheckSWIGPendingException();
+        }
+
+
+        /// <summary>
+        /// Un-apply the given SpanStyle on all ranges of text.<br />
+        /// </summary>
+        /// <param name="textLabel">The TextLabel control containing the text.</param>
+        /// <param name="span">TThe span of style to apply it on text from startIndex to endIndex</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void DetachSpan(TextLabel textLabel, BaseSpan span)
+        {
+            if (textLabel == null)
+            {
+                throw new ArgumentNullException(null, "textLabel object is null");
+            }
+
+            if (span == null)
+            {
+                throw new ArgumentNullException(null, "span object is null");
+            }
+
+            Interop.Spannable.TextLabel.DetachSpan(textLabel.SwigCPtr,span.SwigCPtr);
+            CheckSWIGPendingException();
+        }
+
+        /// <summary>
+        /// Apply the attached style tags on text ranges.<br />
+        /// </summary>
+        /// <param name="textLabel">The TextLabel control containing the text.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void BuildSpannedText(TextLabel textLabel)
+        {
+            if (textLabel == null)
+            {
+                throw new ArgumentNullException(null, "textLabel object is null");
+            }
+
+            Interop.Spannable.TextLabel.BuildSpannedText(textLabel.SwigCPtr);
+            CheckSWIGPendingException();
+        }
+
+
+        /// <summary>
+        /// Apply the given span on the given range of text.<br />
+        /// </summary>
+        /// <param name="textField">The TextField control containing the text.</param>
+        /// <param name="span">TThe span of style to apply it on text from startIndex to endIndex</param>
+        /// <param name="startIndex">The start index of the text to apply span (included)</param>
+        /// <param name="endIndex">The end index of the text  The end index to apply span (included)</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void AttachSpan(TextField textField, BaseSpan span, int startIndex, int endIndex)
+        {
+            if (textField == null)
+            {
+                throw new ArgumentNullException(null, "textField object is null");
+            }
+
+            if (span == null)
+            {
+                throw new ArgumentNullException(null, "span object is null");
+            }
+
+            ValidateRange(startIndex, endIndex);
+
+            Interop.Spannable.TextField.AttachSpan(textField.SwigCPtr,span.SwigCPtr, (uint)startIndex, (uint)endIndex);
+            CheckSWIGPendingException();
+        }
+
+
+        /// <summary>
+        /// Un-apply the given SpanStyle on all ranges of text.<br />
+        /// </summary>
+        /// <param name="textField">The TextField control containing the text.</param>
+        /// <param name="span">TThe span of style to apply it on text from startIndex to endIndex</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void DetachSpan(TextField textField, BaseSpan span)
+        {
+            if (textField == null)
+            {
+                throw new ArgumentNullException(null, "textField object is null");
+            }
+
+            if (span == null)
+            {
+                throw new ArgumentNullException(null, "span object is null");
+            }
+
+            Interop.Spannable.TextField.DetachSpan(textField.SwigCPtr,span.SwigCPtr);
+            CheckSWIGPendingException();
+        }
+
+        /// <summary>
+        /// Apply the attached style tags on text ranges.<br />
+        /// </summary>
+        /// <param name="textField">The TextField control containing the text.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void BuildSpannedText(TextField textField)
+        {
+            if (textField == null)
+            {
+                throw new ArgumentNullException(null, "textField object is null");
+            }
+
+            Interop.Spannable.TextField.BuildSpannedText(textField.SwigCPtr);
+            CheckSWIGPendingException();
+        }
+
+
+        /// <summary>
+        /// Apply the given span on the given range of text.<br />
+        /// </summary>
+        /// <param name="textEditor">The TextEditor control containing the text.</param>
+        /// <param name="span">TThe span of style to apply it on text from startIndex to endIndex</param>
+        /// <param name="startIndex">The start index of the text to apply span (included)</param>
+        /// <param name="endIndex">The end index of the text  The end index to apply span (included)</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void AttachSpan(TextEditor textEditor, BaseSpan span, int startIndex, int endIndex)
+        {
+            if (textEditor == null)
+            {
+                throw new ArgumentNullException(null, "textEditor object is null");
+            }
+
+            if (span == null)
+            {
+                throw new ArgumentNullException(null, "span object is null");
+            }
+
+            ValidateRange(startIndex, endIndex);
+
+            Interop.Spannable.TextEditor.AttachSpan(textEditor.SwigCPtr,span.SwigCPtr, (uint)startIndex, (uint)endIndex);
+            CheckSWIGPendingException();
+        }
+
+
+        /// <summary>
+        /// Un-apply the given SpanStyle on all ranges of text.<br />
+        /// </summary>
+        /// <param name="textEditor">The TextEditor control containing the text.</param>
+        /// <param name="span">TThe span of style to apply it on text from startIndex to endIndex</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void DetachSpan(TextEditor textEditor, BaseSpan span)
+        {
+            if (textEditor == null)
+            {
+                throw new ArgumentNullException(null, "textEditor object is null");
+            }
+
+            if (span == null)
+            {
+                throw new ArgumentNullException(null, "span object is null");
+            }
+
+            Interop.Spannable.TextEditor.DetachSpan(textEditor.SwigCPtr,span.SwigCPtr);
+            CheckSWIGPendingException();
+        }
+
+        /// <summary>
+        /// Apply the attached style tags on text ranges.<br />
+        /// </summary>
+        /// <param name="textEditor">The TextField control containing the text.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void BuildSpannedText(TextEditor textEditor)
+        {
+            if (textEditor == null)
+            {
+                throw new ArgumentNullException(null, "textEditor object is null");
+            }
+
+            Interop.Spannable.TextEditor.BuildSpannedText(textEditor.SwigCPtr);
+            CheckSWIGPendingException();
+        }
+
+    }
+}

--- a/src/Tizen.NUI/src/public/Text/Spans/BaseSpan.cs
+++ b/src/Tizen.NUI/src/public/Text/Spans/BaseSpan.cs
@@ -1,0 +1,52 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI.Text.Spans
+{
+    /// <summary>
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class BaseSpan : Disposable, ISpan
+    {
+
+        internal BaseSpan(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// <summary>
+        /// </summary>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string GetMarkupTagName()
+        {
+            string ret =  Interop.BaseSpan.GetMarkupTagName(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.BaseSpan.DeleteBaseSpan(swigCPtr);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/Text/Spans/ForegroundColorSpan.cs
+++ b/src/Tizen.NUI/src/public/Text/Spans/ForegroundColorSpan.cs
@@ -1,0 +1,82 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI.Text.Spans
+{
+    /// <summary>
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class ForegroundColorSpan : BaseSpan
+    {
+
+        /// <summary>
+        /// Create foreground color span Set and set color for it.<br />
+        /// </summary>
+        /// <param name="color">The fore color</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static ForegroundColorSpan CreateWithForegroundColor(Color color)
+        {
+            return ForegroundColorSpanBuilder.Initialize().WithForegroundColor(color).Build();
+        }
+
+        internal ForegroundColorSpan(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// <summary>
+        /// The fore-color in color-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Color ForegroundColor
+        {
+            get
+            {
+                Color ret = new Color(Interop.ForegroundColorSpan.ForegroundColorGet(SwigCPtr), true);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// Whether the fore color is defined in color-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool ForegroundColorDefined
+        {
+            get
+            {
+                bool ret = Interop.ForegroundColorSpan.ForegroundColorDefinedGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.ForegroundColorSpan.DeleteForegroundColorSpan(swigCPtr);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/Text/Spans/ForegroundColorSpanBuilder.cs
+++ b/src/Tizen.NUI/src/public/Text/Spans/ForegroundColorSpanBuilder.cs
@@ -1,0 +1,75 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI.Text.Spans
+{
+    /// <summary>
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class ForegroundColorSpanBuilder : Disposable
+    {
+
+        /// <summary>
+        /// Creates a new ForegroundColorSpanBuilder object<br />
+        /// </summary>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static ForegroundColorSpanBuilder Initialize( )
+        {
+            ForegroundColorSpanBuilder ret = new ForegroundColorSpanBuilder(Interop.ForegroundColorSpanBuilder.Initialize( ), true);
+            return ret;
+        }
+
+        internal ForegroundColorSpanBuilder(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// <summary>
+        /// Create an instance for color-span<br />
+        /// </summary>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ForegroundColorSpan Build( )
+        {
+            ForegroundColorSpan ret = new ForegroundColorSpan(Interop.ForegroundColorSpanBuilder.Build(SwigCPtr), true);
+            return ret;
+        }
+
+        /// <summary>
+        /// Set fore color for span<br />
+        /// </summary>
+        /// <param name="color">The fore color</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ForegroundColorSpanBuilder WithForegroundColor(Color color)
+        {
+            ForegroundColorSpanBuilder ret = new ForegroundColorSpanBuilder(Interop.ForegroundColorSpanBuilder.WithForegroundColor(SwigCPtr,Vector4.getCPtr(color)), true);
+            return ret;
+        }
+
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.ForegroundColorSpanBuilder.DeleteForegroundColorSpanBuilder(swigCPtr);
+        }
+
+    }
+}

--- a/src/Tizen.NUI/src/public/Text/Spans/ISpan.cs
+++ b/src/Tizen.NUI/src/public/Text/Spans/ISpan.cs
@@ -1,0 +1,27 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using Tizen.NUI.Binding;
+
+namespace Tizen.NUI.Text.Spans
+{
+    public interface ISpan
+    {
+        string GetMarkupTagName();
+    }
+}
+

--- a/src/Tizen.NUI/src/public/Window/BorderWindow.cs
+++ b/src/Tizen.NUI/src/public/Window/BorderWindow.cs
@@ -276,9 +276,7 @@ namespace Tizen.NUI
                 // Add a view to the border layer.
                 GetBorderWindowBottomLayer().Add(rootView);
 
-                // TODO after the emulator issue is resolved, use the FocusChanged event.
-                //FocusChanged += OnWindowFocusChanged;
-                InterceptTouchEvent += OnWindowInterceptTouched;
+                FocusChanged += OnWindowFocusChanged;
 
                 return true;
             }
@@ -289,25 +287,14 @@ namespace Tizen.NUI
             }
         }
 
-        private bool OnWindowInterceptTouched(object sender, Window.TouchEventArgs e)
+        private void OnWindowFocusChanged(object sender, Window.FocusChangedEventArgs e)
         {
-            if (e.Touch.GetState(0) == PointStateType.Down && IsMaximized() == false)
+            if (e.FocusGained == true && IsMaximized() == false)
             {
                 // Raises the window when the window is focused.
                 Raise();
             }
-            return false;
         }
-
-        // TODO after the emulator issue is resolved, use the FocusChanged event.
-        // private void OnWindowFocusChanged(object sender, Window.FocusChangedEventArgs e)
-        // {
-        //     if (e.FocusGained == true && IsMaximized() == false)
-        //     {
-        //         // Raises the window when the window is focused.
-        //         Raise();
-        //     }
-        // }
 
         /// Create the border UI.
         private bool CreateBorder()
@@ -541,7 +528,7 @@ namespace Tizen.NUI
         internal void DisposeBorder()
         {
             Resized -= OnBorderWindowResized;
-            InterceptTouchEvent -= OnWindowInterceptTouched;
+            FocusChanged -= OnWindowFocusChanged;
             borderInterface.Dispose();
             GetBorderWindowBottomLayer().Dispose();
         }

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSBaseSpan.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSBaseSpan.cs
@@ -1,0 +1,89 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text/Spans")]
+    public class PublicBaseSpanTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("BaseSpan GetMarkupTagName.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.BaseSpan.GetMarkupTagName M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void BaseSpanGetMarkupTagName()
+        {
+            tlog.Debug(tag, $"BaseSpanGetMarkupTagName START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                var result = testingTarget.GetMarkupTagName();
+                Assert.IsNotNull(result, "null handle");
+                Assert.IsInstanceOf<string>(result, "Should return string instance.");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"BaseSpanGetMarkupTagName END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("BaseSpan Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.BaseSpan.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void BaseSpanDispose()
+        {
+            tlog.Debug(tag, $"BaseSpanDispose START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(testingTarget, "Should return BaseSpan instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"BaseSpanDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpan.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpan.cs
@@ -1,0 +1,122 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text/Spans")]
+    public class PublicForegroundColorSpanTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan ForegroundColor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.ForegroundColor A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanForegroundColor()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanForegroundColor START");
+
+            Color expected = Color.Green;
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                var resutl = testingTarget.ForegroundColor;
+                Assert.AreEqual(true, TestUtils.CheckColor(expected, resutl), "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanForegroundColor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan ForegroundColorDefined.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.ForegroundColorDefined A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanForegroundColorDefined()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanForegroundColorDefined START");
+
+            Color expected = Color.Green;
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                var resutl = testingTarget.ForegroundColorDefined;
+                Assert.AreEqual(true, resutl, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanForegroundColorDefined END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanDispose()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanDispose START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"ForegroundColorSpanDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpanBuilder.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpanBuilder.cs
@@ -1,0 +1,118 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text/Spans")]
+    public class PublicForegroundColorSpanBuilderTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpanBuilder Initialize.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpanBuilder.Initialize M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanBuilderInitialize()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderInitialize START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpanBuilder>(testingTarget, "Should return ForegroundColorSpanBuilder instance.");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderInitialize END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpanBuilder Build.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpanBuilder.Build M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanBuilderBuild()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderBuild START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderBuild END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpanBuilder WithForegroundColor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpanBuilder.WithForegroundColor M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanBuilderWithForegroundColor()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderWithForegroundColor START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green);
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpanBuilder>(testingTarget, "Should return ForegroundColorSpanBuilder instance.");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderWithForegroundColor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpanBuilder.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanBuilderDispose()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderDispose START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpanBuilder>(testingTarget, "Should return ForegroundColorSpanBuilder instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/TSSpannable.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/TSSpannable.cs
@@ -1,0 +1,330 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+using Tizen.NUI.Text;
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text")]
+    public class PublicSpannableTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable AttachSpan on TextLabel.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.AttachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableAttachSpanTextLabel()
+        {
+            tlog.Debug(tag, $"SpannableAttachSpanTextLabel START");
+
+            var testingTarget = new TextLabel(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.AttachSpan(testingTarget,span,3,8);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableAttachSpanTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable AttachSpan on TextEditor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.AttachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableAttachSpanTextEditor()
+        {
+            tlog.Debug(tag, $"SpannableAttachSpanTextEditor START");
+
+            var testingTarget = new TextEditor(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.AttachSpan(testingTarget,span,3,8);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableAttachSpanTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable AttachSpan on TextField.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.AttachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableAttachSpanTextField()
+        {
+            tlog.Debug(tag, $"SpannableAttachSpanTextField START");
+
+            var testingTarget = new TextField(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.AttachSpan(testingTarget,span,3,8);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableAttachSpanTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable DetachSpan on TextLabel.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.DetachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableDetachSpanTextLabel()
+        {
+            tlog.Debug(tag, $"SpannableDetachSpanTextLabel START");
+
+            var testingTarget = new TextLabel(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.DetachSpan(testingTarget,span);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableDetachSpanTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable DetachSpan on TextEditor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.DetachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableDetachSpanTextEditor()
+        {
+            tlog.Debug(tag, $"SpannableDetachSpanTextEditor START");
+
+            var testingTarget = new TextEditor(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.DetachSpan(testingTarget,span);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableDetachSpanTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable DetachSpan on TextField.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.DetachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableDetachSpanTextField()
+        {
+            tlog.Debug(tag, $"SpannableDetachSpanTextField START");
+
+            var testingTarget = new TextField(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.DetachSpan(testingTarget,span);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableDetachSpanTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable BuildSpannedText on TextLabel.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.BuildSpannedText M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableBuildSpannedTextTextLabel()
+        {
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextLabel START");
+
+            var testingTarget = new TextLabel(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.BuildSpannedText(testingTarget);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable BuildSpannedText on TextEditor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.BuildSpannedText M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableBuildSpannedTextTextEditor()
+        {
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextEditor START");
+
+            var testingTarget = new TextEditor(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.BuildSpannedText(testingTarget);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable BuildSpannedText on TextField.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.BuildSpannedText M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableBuildSpannedTextTextField()
+        {
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextField START");
+
+            var testingTarget = new TextField(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.BuildSpannedText(testingTarget);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextEditor END (OK)");
+        }
+
+
+
+    }
+}

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/TestUtils.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/TestUtils.cs
@@ -1,0 +1,31 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Tizen.NUI.Devel.Tests
+{
+
+
+    public class TestUtils
+    {
+
+        public static bool CheckColor(Color colorSrc, Color colorDst)
+        {
+            if (colorSrc.R == colorDst.R && colorSrc.G == colorDst.G && colorSrc.B == colorDst.B && colorSrc.A == colorDst.A)
+                return true;
+
+            return false;
+        }
+
+        public static bool CheckColor(Vector4 colorSrc, Vector4 colorDst)
+        {
+            if (colorSrc.X == colorDst.X && colorSrc.Y == colorDst.Y && colorSrc.Z == colorDst.Z && colorSrc.W == colorDst.W)
+                return true;
+
+            return false;
+        }
+
+    }
+}

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSBaseSpan.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSBaseSpan.cs
@@ -1,0 +1,89 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text/Spans")]
+    public class PublicBaseSpanTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("BaseSpan GetMarkupTagName.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.BaseSpan.GetMarkupTagName M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void BaseSpanGetMarkupTagName()
+        {
+            tlog.Debug(tag, $"BaseSpanGetMarkupTagName START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                var result = testingTarget.GetMarkupTagName();
+                Assert.IsNotNull(result, "null handle");
+                Assert.IsInstanceOf<string>(result, "Should return string instance.");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"BaseSpanGetMarkupTagName END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("BaseSpan Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.BaseSpan.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void BaseSpanDispose()
+        {
+            tlog.Debug(tag, $"BaseSpanDispose START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(testingTarget, "Should return BaseSpan instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"BaseSpanDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpan.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpan.cs
@@ -1,0 +1,122 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text/Spans")]
+    public class PublicForegroundColorSpanTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan ForegroundColor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.ForegroundColor A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanForegroundColor()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanForegroundColor START");
+
+            Color expected = Color.Green;
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                var resutl = testingTarget.ForegroundColor;
+                Assert.AreEqual(true, TestUtils.CheckColor(expected, resutl), "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanForegroundColor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan ForegroundColorDefined.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.ForegroundColorDefined A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanForegroundColorDefined()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanForegroundColorDefined START");
+
+            Color expected = Color.Green;
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                var resutl = testingTarget.ForegroundColorDefined;
+                Assert.AreEqual(true, resutl, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanForegroundColorDefined END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanDispose()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanDispose START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"ForegroundColorSpanDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpanBuilder.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpanBuilder.cs
@@ -1,0 +1,118 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text/Spans")]
+    public class PublicForegroundColorSpanBuilderTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpanBuilder Initialize.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpanBuilder.Initialize M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanBuilderInitialize()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderInitialize START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpanBuilder>(testingTarget, "Should return ForegroundColorSpanBuilder instance.");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderInitialize END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpanBuilder Build.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpanBuilder.Build M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanBuilderBuild()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderBuild START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderBuild END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpanBuilder WithForegroundColor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpanBuilder.WithForegroundColor M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanBuilderWithForegroundColor()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderWithForegroundColor START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green);
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpanBuilder>(testingTarget, "Should return ForegroundColorSpanBuilder instance.");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderWithForegroundColor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpanBuilder.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanBuilderDispose()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderDispose START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpanBuilder>(testingTarget, "Should return ForegroundColorSpanBuilder instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/TSSpannable.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/TSSpannable.cs
@@ -1,0 +1,330 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+using Tizen.NUI.Text;
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text")]
+    public class PublicSpannableTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable AttachSpan on TextLabel.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.AttachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableAttachSpanTextLabel()
+        {
+            tlog.Debug(tag, $"SpannableAttachSpanTextLabel START");
+
+            var testingTarget = new TextLabel(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.AttachSpan(testingTarget,span,3,8);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableAttachSpanTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable AttachSpan on TextEditor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.AttachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableAttachSpanTextEditor()
+        {
+            tlog.Debug(tag, $"SpannableAttachSpanTextEditor START");
+
+            var testingTarget = new TextEditor(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.AttachSpan(testingTarget,span,3,8);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableAttachSpanTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable AttachSpan on TextField.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.AttachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableAttachSpanTextField()
+        {
+            tlog.Debug(tag, $"SpannableAttachSpanTextField START");
+
+            var testingTarget = new TextField(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.AttachSpan(testingTarget,span,3,8);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableAttachSpanTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable DetachSpan on TextLabel.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.DetachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableDetachSpanTextLabel()
+        {
+            tlog.Debug(tag, $"SpannableDetachSpanTextLabel START");
+
+            var testingTarget = new TextLabel(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.DetachSpan(testingTarget,span);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableDetachSpanTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable DetachSpan on TextEditor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.DetachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableDetachSpanTextEditor()
+        {
+            tlog.Debug(tag, $"SpannableDetachSpanTextEditor START");
+
+            var testingTarget = new TextEditor(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.DetachSpan(testingTarget,span);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableDetachSpanTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable DetachSpan on TextField.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.DetachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableDetachSpanTextField()
+        {
+            tlog.Debug(tag, $"SpannableDetachSpanTextField START");
+
+            var testingTarget = new TextField(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.DetachSpan(testingTarget,span);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableDetachSpanTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable BuildSpannedText on TextLabel.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.BuildSpannedText M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableBuildSpannedTextTextLabel()
+        {
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextLabel START");
+
+            var testingTarget = new TextLabel(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.BuildSpannedText(testingTarget);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable BuildSpannedText on TextEditor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.BuildSpannedText M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableBuildSpannedTextTextEditor()
+        {
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextEditor START");
+
+            var testingTarget = new TextEditor(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.BuildSpannedText(testingTarget);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable BuildSpannedText on TextField.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.BuildSpannedText M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableBuildSpannedTextTextField()
+        {
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextField START");
+
+            var testingTarget = new TextField(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.BuildSpannedText(testingTarget);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextEditor END (OK)");
+        }
+
+
+
+    }
+}

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/TestUtils.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/TestUtils.cs
@@ -1,0 +1,31 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Tizen.NUI.Devel.Tests
+{
+
+
+    public class TestUtils
+    {
+
+        public static bool CheckColor(Color colorSrc, Color colorDst)
+        {
+            if (colorSrc.R == colorDst.R && colorSrc.G == colorDst.G && colorSrc.B == colorDst.B && colorSrc.A == colorDst.A)
+                return true;
+
+            return false;
+        }
+
+        public static bool CheckColor(Vector4 colorSrc, Vector4 colorDst)
+        {
+            if (colorSrc.X == colorDst.X && colorSrc.Y == colorDst.Y && colorSrc.Z == colorDst.Z && colorSrc.W == colorDst.W)
+                return true;
+
+            return false;
+        }
+
+    }
+}


### PR DESCRIPTION
### Description of Change ###
Spannable: it is a text module. It allows application developers to modify text style dynamically at runtime on character level.
The application can attach and unattach spans on range of text for text-controller.

BaseSpan: Base structure for different text-spans.
ColorSpan: Span to change fore color of font


### API Changes ###

Added:
 - Tizen.NUI.Text.Spans.BaseSpan // Class
 - Tizen.NUI.Text.Spans.ColorSpan // Class
 - Tizen.NUI.Text.Spans.ColorSpanBuilder // Class
 - Tizen.NUI.Text.Spans.ISpan // interface
 -  Tizen.NUI.Text.Spannable// Class
- public static void AttachSpan(TextLabel textLabel, BaseSpan span, int startIndex, int endIndex) //Method
- public static void UnAttachSpan(TextLabel textLabel, BaseSpan span)
- public static void BuildSpannedText(TextLabel textLabel)
- public static void AttachSpan(TextField textField, BaseSpan span, int startIndex, int endIndex)
- public static void UnAttachSpan(TextField textField, BaseSpan span)
- public static void BuildSpannedText(TextField textField)
- public static void AttachSpan(TextEditor textEditor, BaseSpan span, int startIndex, int endIndex)
- public static void UnAttachSpan(TextEditor textEditor, BaseSpan span)
- public static void BuildSpannedText(TextEditor textEditor)

### Testcases ###
Added the below to (Tizen.NUI.Devel.Tests.Ubuntu) and (Tizen.NUI.Tests):
- Tizen.NUI.Devel.Tests.PublicBaseSpanTest
- Tizen.NUI.Devel.Tests.PublicColorSpanTest
- Tizen.NUI.Devel.Tests.PublicColorSpanBuilderTest
- Tizen.NUI.Devel.Tests.PublicSpannableTest
- Tizen.NUI.Devel.Tests.TestUtils


**This PR depends on the below patches:**

- https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/279035
- https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/276651

**Here's an example how to use it**
- https://github.com/shrouqsabah/NUI-Test/tree/spannable_core_colorspan/text-spannable
